### PR TITLE
Binary insertion sort example in Scala (DO NOT MERGE!!!)

### DIFF
--- a/app/sort/SortState.scala
+++ b/app/sort/SortState.scala
@@ -1,0 +1,83 @@
+package sort
+
+case class Picture(id: Int)
+
+sealed trait Out
+
+case class CompareRequest[T](a: T, b: T) extends Out
+
+case class SortFinished[T](pictures: Seq[T]) extends Out
+
+
+sealed trait In
+
+case object Init extends In
+
+case class CompareResponse[T](a: T, b: T, gt: Boolean) extends In
+
+
+case class SortState[T](sorted: Seq[T], unsorted: List[T], lowerBoundPosition: Int, upperBoundPosition: Int) {
+  def this(pictures: Seq[T]) {
+    this(pictures.headOption.toSeq, pictures.tail.toList, 0, 0)
+  }
+
+  def receive(in: In): (SortState[T], Out) = {
+    in match {
+      case Init => processInit
+      case x: CompareResponse[T] => processResponse(x)
+    }
+  }
+
+  def processInit: (SortState[T], Out) = {
+    (this, nextAction)
+  }
+
+  def processResponse(compareResponse: CompareResponse[T]): (SortState[T], Out) = {
+    val sortState = updatedWithResponse(compareResponse)
+    (sortState, sortState.nextAction)
+  }
+
+  def updatedWithResponse(compareResponse: CompareResponse[T]): SortState[T] = {
+    require(compareResponse.a == unsorted.head)
+    require(compareResponse.b == sorted(midPosition))
+
+    if (compareResponse.gt) {
+      if (midPosition == upperBoundPosition) {
+        insertAfterPosition(compareResponse.a, upperBoundPosition)
+      } else {
+        copy(lowerBoundPosition = midPosition + 1)
+      }
+    } else {
+      if (midPosition == lowerBoundPosition) {
+        insertAfterPosition(compareResponse.a, lowerBoundPosition - 1)
+      } else {
+        copy(upperBoundPosition = midPosition)
+      }
+    }
+  }
+
+  def insertAfterPosition(picture: T, position: Int): SortState[T] = {
+    require(position >= -1)
+    require(position <= sorted.length)
+
+    val sortedUpdated = if (position > -1) {
+      val h: Seq[T] = sorted.slice(0, position + 1)
+      val t: Seq[T] = sorted.slice(position + 1, sorted.length)
+      (h :+ picture) ++ t
+    } else {
+      picture +: sorted
+    }
+
+    copy(sortedUpdated, unsorted.tail, 0, sortedUpdated.length - 1)
+  }
+
+  def nextAction: Out = {
+    if (unsorted.nonEmpty) {
+      CompareRequest(unsorted.head, sorted(midPosition))
+    } else {
+      SortFinished(sorted)
+    }
+  }
+
+  private def midPosition: Int = (lowerBoundPosition + upperBoundPosition) / 2
+}

--- a/test/sort/SortStateTest.scala
+++ b/test/sort/SortStateTest.scala
@@ -1,0 +1,71 @@
+package sort
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class SortStateTest extends FlatSpec with Matchers{
+
+  val x1 = SortState[Double](Seq(3, 5), List(0), 0, 1)
+  val x2 = SortState[Double](Seq(3, 5), List(4), 0, 1)
+  val x3 = SortState[Double](Seq(3, 5), List(4), 1, 1)
+  val x4 = SortState[Double](Seq(3, 4, 5), List(), 0, 2)
+  val xFinished = SortState[Double](Seq(3, 5), List(), 0, 0)
+
+  val r1 = CompareResponse[Double](0, 3, false)
+  val r2 = CompareResponse[Double](4, 3, true)
+  val r3 = CompareResponse[Double](4, 5, false)
+
+  behavior of "SortStateTest"
+
+  it should "insertAfterPosition" in {
+    x1.insertAfterPosition(0.0, -1) shouldEqual
+      SortState[Double](Seq(0.0, 3, 5), List(), 0, 2)
+
+    x1.insertAfterPosition(0.0, 0) shouldEqual
+      SortState[Double](Seq(3, 0.0, 5), List(), 0, 2)
+
+    x1.insertAfterPosition(0.0, 1) shouldEqual
+      SortState[Double](Seq(3, 5, 0.0), List(), 0, 2)
+  }
+
+  it should "nextAction" in {
+    x1.nextAction shouldEqual CompareRequest(0, 3)
+    x2.nextAction shouldEqual CompareRequest(4, 3)
+    xFinished.nextAction shouldEqual SortFinished(Seq(3, 5))
+  }
+
+  it should "updatedWithResponse" in {
+    x1.updatedWithResponse(r1) shouldEqual SortState(Seq(0, 3, 5), List(), 0, 2)
+    x2.updatedWithResponse(r2) shouldEqual x3
+    x3.updatedWithResponse(r3) shouldEqual x4
+  }
+
+  it should "processResponse" in {
+    x2.processResponse(r2) shouldEqual (x3, CompareRequest(4, 5))
+    x3.processResponse(r3) shouldEqual (x4, SortFinished(Seq(3, 4, 5)))
+  }
+
+  it should "sort correctly" in {
+    def cmp(x: Out): CompareResponse[Double] = {
+      x match {
+        case x: CompareRequest[Double] => CompareResponse(x.a, x.b, x.a > x.b)
+      }
+    }
+
+
+    val unsorted = Seq[Double](4, 3, 5, 1, 4, 0)
+    val sorted = unsorted.sorted
+
+    var (s, o) = new SortState(unsorted).processInit
+    while (!o.isInstanceOf[SortFinished[Double]]){
+      val (s_, o_) = s.processResponse(cmp(o))
+      s = s_
+      o = o_
+    }
+
+    o shouldEqual SortFinished(sorted)
+
+  }
+
+
+
+}


### PR DESCRIPTION
Example how binary insertion sort with comparison done externally can be implemented in plain Scala. This should be easily portable to JS and Redux
  
waiting on typescript refactoring